### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/netlify-daily-build.yml
+++ b/.github/workflows/netlify-daily-build.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   trigger-netlify-build:
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Netlify build hook


### PR DESCRIPTION
Potential fix for [https://github.com/AyushAggarwal1/gst-bill/security/code-scanning/3](https://github.com/AyushAggarwal1/gst-bill/security/code-scanning/3)

In general, you should explicitly set a `permissions` block for each workflow or job so that the `GITHUB_TOKEN` has only the minimal scopes required. If a job doesn’t need `GITHUB_TOKEN` at all, set `permissions: {}` (or `permissions: read-all` / specific reads if needed). This prevents the token from having unintended write access.

For this specific workflow, the `trigger-netlify-build` job only uses `curl` with a secret and does not interact with the GitHub API. Therefore, the safest and clearest fix is to add a `permissions: {}` block for that job, which disables all default permissions for `GITHUB_TOKEN`. Concretely, in `.github/workflows/netlify-daily-build.yml`, add a `permissions: {}` line under `trigger-netlify-build:` (around line 13), indented to the same level as `runs-on:`. No additional imports or methods are needed, as this is purely YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
