### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checkmarx-scan.yaml
+++ b/.github/workflows/checkmarx-scan.yaml
@@ -8,6 +8,9 @@ on:
     - cron: '0 10 * * *'  # Every day at 10:00 UTC
   workflow_dispatch: 
 
+permissions:
+  contents: read
+
 jobs:
   checkmarx-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AyushAggarwal1/gst-bill/security/code-scanning/4](https://github.com/AyushAggarwal1/gst-bill/security/code-scanning/4)

In general, the fix is to explicitly specify `permissions` for the workflow or for the specific job so that the `GITHUB_TOKEN` has only the minimal scopes required. This prevents the workflow from implicitly using potentially broad, inherited defaults.

For this specific workflow, the safest, backwards-compatible change is to add a `permissions` block at the workflow root (applies to all jobs) with `contents: read`. The steps shown only (1) check out code and (2) run a scanning action and (3) upload an artifact. None of these require write access to repository contents, nor administrative scopes. GitHub-hosted `actions/upload-artifact` does not rely on repository write permissions; it uses its own service, so `contents: read` is sufficient.

Concretely, in `.github/workflows/checkmarx-scan.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after current line 9 and before line 11). No additional imports or methods are needed because this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
